### PR TITLE
provide `image_url` in api response

### DIFF
--- a/controllers/api.py
+++ b/controllers/api.py
@@ -50,6 +50,7 @@ def build_map_dict(map):
   map_dict['featured_by'] = map.featured_by.username if map.featured_by else None
   map_dict['tags'] = list(map.tags)
   map_dict['map_id'] = map.map_id
+  map_dict['image_url'] = map.image_url
   return map_dict
 
 


### PR DESCRIPTION
it'd be nice to have this value in an api response. afaict these images are stored on cloud storage? if it's a clean way to get access to map images for a map on numa, then cool... but if these count against the gae quota, then nevermind